### PR TITLE
EventDispatch now works as intended

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.config
 obj/
 build/
+xcode/
 clank
 
 *.swp

--- a/src/core/Component.cpp
+++ b/src/core/Component.cpp
@@ -3,6 +3,9 @@
 #include "GameObject.h"
 #include "EventDispatch.h"
 
+namespace rw
+{
+
 Component::Component():
     _gameObject(nullptr)
 {
@@ -34,3 +37,4 @@ std::shared_ptr<EventDispatch> Component::GetEventDispatch() const
     return _gameObject->GetEventDispatch();
 }
 
+}

--- a/src/core/Component.h
+++ b/src/core/Component.h
@@ -8,6 +8,9 @@
 #include <functional>
 #include <memory>
 
+namespace rw
+{
+
 class GameObject;
 
 class Component : public IEventReceiver, public std::enable_shared_from_this<Component>
@@ -53,14 +56,21 @@ private:
 typedef TypeId ComponentId;
 
 template<class CompT>
-inline ComponentId GetComponentId(const CompT&)
+inline ComponentId GetComponentId()
 {
-    return GetTypeId<Component, CompT>();
+    return ::rw::GetTypeId<Component, CompT>();
 }
 
 template<class CompT>
-inline ComponentId GetComponentId(std::shared_ptr<CompT>)
+inline ComponentId GetComponentId(const CompT&)
 {
-    return GetTypeId<Component, CompT>();
+    return ::rw::GetTypeId<Component, CompT>();
 }
 
+template<class CompT>
+inline ComponentId GetComponentId(const std::shared_ptr<CompT>&)
+{
+    return ::rw::GetTypeId<Component, CompT>();
+}
+
+}

--- a/src/core/Event.h
+++ b/src/core/Event.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "TypeId.h"
-
 #include <memory>
+
+namespace rw
+{
 
 class Event
 {
@@ -15,14 +17,21 @@ private:
 typedef TypeId EventId;
 
 template<class T>
-inline EventId GetEventId(const T&)
+inline EventId GetEventId()
 {
-    return GetTypeId<Event, T>();
+    return ::rw::GetTypeId<Event, T>();
 }
 
 template<class T>
-inline EventId GetEventId(std::shared_ptr<T>)
+inline EventId GetEventId(const T&)
 {
-    return GetTypeId<Event, T>();
+    return ::rw::GetTypeId<Event, T>();
 }
 
+template<class T>
+inline EventId GetEventId(const std::shared_ptr<T>)
+{
+    return ::rw::GetTypeId<Event, T>();
+}
+
+}

--- a/src/core/EventDispatch.cpp
+++ b/src/core/EventDispatch.cpp
@@ -1,21 +1,7 @@
 #include "EventDispatch.h"
 
-
-void EventDispatch::Raise(const std::shared_ptr<Event> event)
+namespace rw
 {
-    std::lock_guard<std::mutex> lock(_mutex);
-
-    EventId id = GetEventId(event);
-
-    if (_subs.count(id) != 0) {
-        std::vector<EventSubscription> *vec;
-        vec = &_subs[id];
-
-        for (int i=0; i<(int)vec->size(); i++) {
-            (*vec)[i].responder(event);
-        }
-    }
-}
 
 void EventDispatch::UnsubscribeAll(std::shared_ptr<IEventReceiver> recv)
 {
@@ -32,4 +18,6 @@ void EventDispatch::UnsubscribeAll(std::shared_ptr<IEventReceiver> recv)
             }
         }
     }
+}
+
 }

--- a/src/core/Except.cpp
+++ b/src/core/Except.cpp
@@ -2,6 +2,9 @@
 #include <sstream>
 #include <stdarg.h>
 
+namespace rw
+{
+
 namespace Internal
 {
 
@@ -22,6 +25,8 @@ void Throw(const char *file, const char *func, int line, const char *msg, ...)
     ss << formatted;
     std::string s = ss.str();
     throw Exception(s);
+}
+
 }
 
 }

--- a/src/core/Except.h
+++ b/src/core/Except.h
@@ -3,6 +3,9 @@
 #include <stdexcept>
 
 
+namespace rw
+{
+
 typedef std::runtime_error Exception;
 
 namespace Internal
@@ -14,5 +17,7 @@ void Throw(const char *file, const char *func, int line, const char *msg, ...);
 
 
 #define THROW(MSG...) \
-    Internal::Throw(__FILE__, __PRETTY_FUNCTION__, __LINE__, MSG)
+    ::rw::Internal::Throw(__FILE__, __PRETTY_FUNCTION__, __LINE__, MSG)
 
+
+}

--- a/src/core/GameObject.cpp
+++ b/src/core/GameObject.cpp
@@ -3,6 +3,9 @@
 
 #include <typeinfo>
 
+namespace rw
+{
+
 GameObject::GameObject(std::shared_ptr<EventDispatch> dispatch)
 {
     _eventDispatch = dispatch;
@@ -27,3 +30,4 @@ std::shared_ptr<EventDispatch> GameObject::GetEventDispatch() const
     return _eventDispatch;
 }
 
+}

--- a/src/core/GameObject.h
+++ b/src/core/GameObject.h
@@ -3,6 +3,9 @@
 #include <vector>
 #include <memory>
 
+namespace rw
+{
+
 class Component;
 class EventDispatch;
 
@@ -20,3 +23,4 @@ private:
     std::shared_ptr<EventDispatch> _eventDispatch;
     std::vector<std::shared_ptr<Component>> _components;
 };
+}

--- a/src/core/IEventReceiver.h
+++ b/src/core/IEventReceiver.h
@@ -1,6 +1,11 @@
 #pragma once
 
+namespace rw
+{
+
 class IEventReceiver
 {
 public:
 };
+
+}

--- a/src/core/TypeId.h
+++ b/src/core/TypeId.h
@@ -2,6 +2,9 @@
 
 #include <typeinfo>
 
+namespace rw
+{
+
 typedef const std::type_info* TypeId;
 
 template<class BaseT, class SubT>
@@ -11,3 +14,4 @@ inline TypeId GetTypeId()
     return &typeid(SubT);
 }
 
+}

--- a/test/EventTests.cpp
+++ b/test/EventTests.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+#include "core/Event.h"
+#include "core/EventDispatch.h"
+
+namespace rw
+{
+
+class IntEvent : public Event
+{
+public:
+    IntEvent(int n) { _n = n; }
+    int GetN() const { return _n; }
+
+private:
+    int _n;
+};
+
+class StringEvent : public Event
+{
+public:
+    StringEvent(std::string s) { _s = s; }
+    std::string GetString() const { return _s; }
+
+private:
+    std::string _s;
+};
+
+
+class TestReceiver : public IEventReceiver
+{
+public:
+    TestReceiver()
+    {
+        receivedInt = -1;
+    }
+
+    void OnStringEvent(const std::shared_ptr<StringEvent> sevt)
+    {
+        printf("Received StringEvent\n");
+        receivedString = sevt->GetString();
+    }
+
+    void OnIntEvent(const std::shared_ptr<IntEvent> ievt)
+    {
+        printf("Received IntEvent\n");
+        receivedInt = ievt->GetN();
+    }
+
+    std::string receivedString;
+    int receivedInt;
+};
+
+
+TEST(EventTest, EventIdsDifferBetweenClasses)
+{
+    // Pretty much the whole foundation of the EventDispatch system
+    // is based around these assumptions, so we'd be damned if they
+    // weren't tested properly :)
+    ASSERT_NE(GetEventId<IntEvent>(), GetEventId<Event>());
+    ASSERT_NE(GetEventId<IntEvent>(), GetEventId<StringEvent>());
+
+    // Also just to make sure the overridden functions work properly..
+    IntEvent ie(5);
+    StringEvent se("hei");
+    ASSERT_NE(GetEventId(ie), GetEventId(se));
+}
+
+TEST(EventTest, SimpleDispatch)
+{
+    EventDispatch dispatch;
+    std::shared_ptr<TestReceiver> irecv, srecv;
+    irecv = std::make_shared<TestReceiver>();
+    srecv = std::make_shared<TestReceiver>();
+
+    // We'll need to wrap this cleanly in the final API, but this is the gist of what
+    // should happen. This cryptic nonsense needs to be buried behind seven abstractions,
+    // but once wrapped the final usage is very elegant.
+    std::function<void(const std::shared_ptr<IntEvent>)> ifunc;
+    ifunc = std::bind(&TestReceiver::OnIntEvent, irecv.get(), std::placeholders::_1);
+    dispatch.Subscribe(irecv, ifunc);
+
+    std::function<void(const std::shared_ptr<StringEvent>)> sfunc;
+    sfunc = std::bind(&TestReceiver::OnStringEvent, srecv, std::placeholders::_1);
+    dispatch.Subscribe(srecv, sfunc);
+
+    // Start by ensuring that we're properly un-initialized.
+    ASSERT_EQ(-1, irecv->receivedInt);
+    ASSERT_EQ(-1, srecv->receivedInt);
+    ASSERT_EQ("", srecv->receivedString);
+    ASSERT_EQ("", irecv->receivedString);
+
+    std::shared_ptr<IntEvent> ievt = std::make_shared<IntEvent>(1);
+    std::shared_ptr<StringEvent> sevt = std::make_shared<StringEvent>("a");
+
+    // TEST 1: Raise the int event. This should only trigger an event in the irecv
+    dispatch.Raise(ievt);
+    ASSERT_EQ(1, irecv->receivedInt);
+    ASSERT_EQ(-1, srecv->receivedInt);
+
+    // TEST 2: Raise the string event. Vice versa.
+    dispatch.Raise(sevt);
+    ASSERT_EQ("", irecv->receivedString);
+    ASSERT_NE("", srecv->receivedString);
+
+    // TEST 3: Unsubscribe irecv and raise ievt again. It should no longer update.
+    ievt = std::make_shared<IntEvent>(2);
+    dispatch.UnsubscribeAll(irecv);
+    dispatch.Raise(ievt);
+    ASSERT_EQ(1, irecv->receivedInt);
+    ASSERT_EQ(-1, srecv->receivedInt);
+
+    // TEST 4: Resubscribe the irecv and raise ievt yet again
+    dispatch.Subscribe(irecv, ifunc);
+    dispatch.Raise(ievt);
+    ASSERT_EQ(2, irecv->receivedInt);
+}
+
+}

--- a/test/GameObjectTests.cpp
+++ b/test/GameObjectTests.cpp
@@ -2,9 +2,14 @@
 #include "core/GameObject.h"
 #include "core/EventDispatch.h"
 
+namespace rw
+{
+
 TEST(GameObjectTests, DummyTest)
 {
     std::shared_ptr<EventDispatch> dispatch;
     std::shared_ptr<GameObject> gob = std::make_shared<GameObject>(dispatch);
     ASSERT_EQ(gob->GetEventDispatch(), dispatch);
+}
+
 }


### PR DESCRIPTION
The EventDispatch class is receiving a bit too much template-voodoo for
my liking, but it will (hopefully) make custom Events easier to
implement, as the system will figure out on it's own how this should be
handled.

Regardless of whether or not the template implementations stays, the
APIs should remain consistent. It's therefore important that the
template types (to the greatest extent possible) is automatically
inferreable.