### PR TITLE
Components can now Subscribe to events

### DIFF
--- a/src/core/Component.cpp
+++ b/src/core/Component.cpp
@@ -23,7 +23,7 @@ void Component::OnAttach(std::shared_ptr<GameObject> gameObject)
         THROW("Already added to a GameObject");
     }
 
-    if (_gameObject != nullptr) {
+    if (gameObject != nullptr) {
         _gameObject = gameObject;
         RegisterSubscriptions();
     } else {

--- a/src/core/EventDispatch.h
+++ b/src/core/EventDispatch.h
@@ -41,10 +41,12 @@ public:
     }
 
     template<typename EType>
-    void Subscribe(std::shared_ptr<IEventReceiver> recv, std::function<void(const std::shared_ptr<EType>)> cb)
+    void Subscribe(std::shared_ptr<IEventReceiver> recv,
+                   std::function<void(const std::shared_ptr<EType>)> cb)
     {
         std::lock_guard<std::mutex> lock(_mutex);
-        static_assert(std::is_base_of<Event, EType>::value, "EType must be subclass of Event");
+        static_assert(std::is_base_of<Event, EType>::value,
+                      "EType must be subclass of Event");
 
         EventSubscription sub;
         sub.receiver = recv;

--- a/src/core/GameObject.cpp
+++ b/src/core/GameObject.cpp
@@ -23,6 +23,7 @@ void GameObject::AddComponent(std::shared_ptr<Component> component)
     // TODO: We may want to ensure that we're only ever adding
     // one of each component-type to each gameobject.
     _components.push_back(component);
+    component->OnAttach(shared_from_this());
 }
 
 std::shared_ptr<EventDispatch> GameObject::GetEventDispatch() const

--- a/src/core/GameObject.h
+++ b/src/core/GameObject.h
@@ -9,7 +9,7 @@ namespace rw
 class Component;
 class EventDispatch;
 
-class GameObject
+class GameObject : public std::enable_shared_from_this<GameObject>
 {
 public:
     GameObject(std::shared_ptr<EventDispatch> dispatch);

--- a/test/EventTests.cpp
+++ b/test/EventTests.cpp
@@ -4,6 +4,8 @@
 
 namespace rw
 {
+namespace test
+{
 
 class IntEvent : public Event
 {
@@ -115,4 +117,5 @@ TEST(EventTest, SimpleDispatch)
     ASSERT_EQ(2, irecv->receivedInt);
 }
 
+}
 }

--- a/test/GameObjectTests.cpp
+++ b/test/GameObjectTests.cpp
@@ -1,15 +1,70 @@
 #include <gtest/gtest.h>
 #include "core/GameObject.h"
 #include "core/EventDispatch.h"
+#include "core/Component.h"
 
 namespace rw
 {
+namespace test
+{
+
+class TestEvent : public Event
+{
+public:
+    TestEvent(int n) { _n = n; }
+    int GetN() const { return _n; }
+private:
+    int _n;
+};
+
+class TestComponent : public Component
+{
+public:
+    TestComponent()
+    {
+        received = -1;
+        registered = false;
+    }
+
+    void RegisterSubscriptions() override
+    {
+        registered = true;
+        Subscribe(&TestComponent::OnEvent);
+    }
+
+    // Public for ease of access
+    int received;
+    bool registered;
+
+private:
+    void OnEvent(const std::shared_ptr<TestEvent> e)
+    {
+        received = e->GetN();
+    }
+
+};
+
 
 TEST(GameObjectTests, DummyTest)
 {
-    std::shared_ptr<EventDispatch> dispatch;
+    std::shared_ptr<EventDispatch> dispatch = std::make_shared<EventDispatch>();
     std::shared_ptr<GameObject> gob = std::make_shared<GameObject>(dispatch);
     ASSERT_EQ(gob->GetEventDispatch(), dispatch);
 }
 
+TEST(GameObjectTests, ComponentSubscription)
+{
+    std::shared_ptr<EventDispatch> dispatch = std::make_shared<EventDispatch>();
+    std::shared_ptr<GameObject> gob = std::make_shared<GameObject>(dispatch);
+
+    std::shared_ptr<TestComponent> comp = std::make_shared<TestComponent>();
+    gob->AddComponent(comp);
+    ASSERT_TRUE(comp->registered);
+
+    std::shared_ptr<TestEvent> evt = std::make_shared<TestEvent>(5);
+    dispatch->Raise(evt);
+    ASSERT_EQ(5, comp->received);
+}
+
+}
 }


### PR DESCRIPTION
Added a new shorthand for subscribing to events. The new Subscribe
method is doubly-templated for inference of the caller's class and the
event of which the class should subcribe to.

We are currently only able to subscribe using metods on the form:
    void (ComponentType::*)(const std::shared_ptr<EventType>)

I don't foresee this becoming an issue anytime soon, and as such I don't
want to drown everything in templates any more than I already have.